### PR TITLE
Return actual R* distribution

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 [compat]
 AbstractFFTs = "0.5, 1"
 DataAPI = "1.6"
-Distributions = "0.24, 0.25"
+Distributions = "0.25"
 MLJModelInterface = "1"
 SpecialFunctions = "0.8, 0.9, 0.10, 1"
 StatsBase = "0.33"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 InferenceDiagnostics = "be115224-59cd-429b-ad48-344e309966f0"
+MLJBase = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
 MLJModels = "d491faf4-2d78-11e9-2867-c94bc002c0b7"
 MLJXGBoostInterface = "54119dfa-1dab-4055-a167-80440f4f7a91"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
@@ -8,6 +9,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 [compat]
 Documenter = "0.27"
 InferenceDiagnostics = "0.1"
+MLJBase = "0.18"
 MLJModels = "0.14"
 MLJXGBoostInterface = "0.1"
 julia = "1.3"

--- a/src/rstar.jl
+++ b/src/rstar.jl
@@ -72,10 +72,7 @@ function rstar(
     # train classifier on training data
     ycategorical = MLJModelInterface.categorical(y)
     fitresult, _ = MLJModelInterface.fit(
-        classifier,
-        verbosity,
-        Tables.table(x[train_ids, :]),
-        ycategorical[train_ids],
+        classifier, verbosity, Tables.table(x[train_ids, :]), ycategorical[train_ids]
     )
 
     # compute predictions on test data
@@ -116,7 +113,7 @@ function rstar_distribution(
 
     # scale distribution to support in `[0, nclasses]`
     nclasses = length(MLJModelInterface.classes(ytest))
-    scaled_distribution = (nclasses // length(predictions)) * distribution
+    scaled_distribution = (nclasses//length(predictions)) * distribution
 
     return scaled_distribution
 end

--- a/src/rstar.jl
+++ b/src/rstar.jl
@@ -18,10 +18,10 @@ The `classifier` has to be a supervised classifier of the MLJ framework (see the
 for a list of supported models). It is trained with a `subset` of the samples. The training
 of the classifier can be inspected by adjusting the `verbosity` level.
 
-If the classifier is probabilistic, i.e., if it outputs probabilities of classes, the scaled
-Poisson-binomial distribution of the ``R^*`` statistic is returned (algorithm 2). If the
-classifier is deterministic, i.e., if it predicts a class, the value of the ``R^*``
-statistic is returned (algorithm 1).
+If the classifier is deterministic, i.e., if it predicts a class, the value of the ``R^*``
+statistic is returned (algorithm 1). If the classifier is probabilistic, i.e., if it outputs
+probabilities of classes, the scaled Poisson-binomial distribution of the ``R^*`` statistic
+is returned (algorithm 2).
 
 !!! note
     The correctness of the statistic depends on the convergence of the `classifier` used
@@ -30,17 +30,35 @@ statistic is returned (algorithm 1).
 # Examples
 
 ```jldoctest rstar
-julia> using MLJModels, Statistics
+julia> using MLJBase, MLJModels, Statistics
 
 julia> XGBoost = @load XGBoostClassifier verbosity=0;
 
 julia> samples = fill(4.0, 300, 2);
 
 julia> chain_indices = repeat(1:3; outer=100);
+```
 
+One can compute the distribution of the ``R^*`` statistic (algorithm 2) with the
+probabilistic classifier.
+
+```jldoctest rstar
 julia> distribution = rstar(XGBoost(), samples, chain_indices);
 
 julia> isapprox(mean(distribution), 1; atol=0.1)
+true
+```
+
+For deterministic classifiers, a single ``R^*`` statistic (algorithm 1) is returned.
+Deterministic classifiers can also be derived from probabilistic classifiers by e.g.
+predicting the mode. In MLJ this corresponds to a pipeline of models.
+
+```jldoctest rstar
+julia> @pipeline XGBoost name=XGBoostDeterministic operation=predict_mode;
+
+julia> value = rstar(XGBoostDeterministic(), samples, chain_indices);
+
+julia> isapprox(value, 1; atol=0.1)
 true
 ```
 

--- a/src/rstar.jl
+++ b/src/rstar.jl
@@ -54,7 +54,7 @@ Deterministic classifiers can also be derived from probabilistic classifiers by 
 predicting the mode. In MLJ this corresponds to a pipeline of models.
 
 ```jldoctest rstar
-julia> @pipeline XGBoost name=XGBoostDeterministic operation=predict_mode;
+julia> @pipeline XGBoost name = XGBoostDeterministic operation = predict_mode;
 
 julia> value = rstar(XGBoostDeterministic(), samples, chain_indices);
 

--- a/src/rstar.jl
+++ b/src/rstar.jl
@@ -13,10 +13,10 @@ Compute the distribution of the ``R^*`` convergence statistic of the `samples` w
 
 This implementation is an adaption of algorithms 1 and 2 described by Lambert and Vehtari.
 
-The `classifier` has to be a supervised classifier of the MLJ framework (see
-https://alan-turing-institute.github.io/MLJ.jl/dev/list_of_supported_models/#model_list for
-a list of supported models). It is trained with a `subset` of the samples. The training of
-the classifier can be inspected by adjusting the `verbosity` level.
+The `classifier` has to be a supervised classifier of the MLJ framework (see the
+[MLJ documentation](https://alan-turing-institute.github.io/MLJ.jl/dev/list_of_supported_models/#model_list]
+for a list of supported models). It is trained with a `subset` of the samples. The training
+of the classifier can be inspected by adjusting the `verbosity` level.
 
 If the classifier is probabilistic, i.e., if it outputs probabilities of classes, the
 distribution of the ``R^*`` statistic is a scaled Poisson-binomial distribution. If the

--- a/src/rstar.jl
+++ b/src/rstar.jl
@@ -14,7 +14,7 @@ Compute the distribution of the ``R^*`` convergence statistic of the `samples` w
 This implementation is an adaption of algorithms 1 and 2 described by Lambert and Vehtari.
 
 The `classifier` has to be a supervised classifier of the MLJ framework (see the
-[MLJ documentation](https://alan-turing-institute.github.io/MLJ.jl/dev/list_of_supported_models/#model_list]
+[MLJ documentation](https://alan-turing-institute.github.io/MLJ.jl/dev/list_of_supported_models/#model_list)
 for a list of supported models). It is trained with a `subset` of the samples. The training
 of the classifier can be inspected by adjusting the `verbosity` level.
 

--- a/test/rstar/Project.toml
+++ b/test/rstar/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 InferenceDiagnostics = "be115224-59cd-429b-ad48-344e309966f0"
+MLJBase = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
 MLJLIBSVMInterface = "61c7150f-6c77-4bb1-949c-13197eac2a52"
 MLJModels = "d491faf4-2d78-11e9-2867-c94bc002c0b7"
 MLJXGBoostInterface = "54119dfa-1dab-4055-a167-80440f4f7a91"
@@ -9,6 +10,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 Distributions = "0.25"
 InferenceDiagnostics = "0.1"
+MLJBase = "0.18"
 MLJLIBSVMInterface = "0.1"
 MLJModels = "0.14"
 MLJXGBoostInterface = "0.1"

--- a/test/rstar/Project.toml
+++ b/test/rstar/Project.toml
@@ -1,12 +1,15 @@
 [deps]
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 InferenceDiagnostics = "be115224-59cd-429b-ad48-344e309966f0"
+MLJLIBSVMInterface = "61c7150f-6c77-4bb1-949c-13197eac2a52"
 MLJModels = "d491faf4-2d78-11e9-2867-c94bc002c0b7"
 MLJXGBoostInterface = "54119dfa-1dab-4055-a167-80440f4f7a91"
-Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
+Distributions = "0.25"
 InferenceDiagnostics = "0.1"
+MLJLIBSVMInterface = "0.1"
 MLJModels = "0.14"
 MLJXGBoostInterface = "0.1"
 julia = "1.3"

--- a/test/rstar/runtests.jl
+++ b/test/rstar/runtests.jl
@@ -12,15 +12,14 @@ using Test
     N = 1_000
 
     @testset "examples (classifier = $classifier)" for classifier in classifiers
-        # Compute distribution of R⋆ statistic for a mixed chain.
+        # Compute R⋆ statistic for a mixed chain.
         samples = randn(N, 2)
         dist = rstar(classifier, randn(N, 2), rand(1:3, N))
 
-        # Mean of the resulting distribution should be focused around 1, i.e., the
-        # classifier does not perform better than random guessing.
+        # Mean of the statistic should be focused around 1, i.e., the classifier does not
+        # perform better than random guessing.
         if classifier isa MLJModels.Deterministic
-            @test dist isa Dirac
-            @test 0 <= minimum(dist) <= maximum(dist) <= 3
+            @test dist isa Float64
         else
             @test dist isa LocationScale
             @test dist.ρ isa PoissonBinomial
@@ -29,16 +28,15 @@ using Test
         end
         @test mean(dist) ≈ 1 rtol = 0.2
 
-        # Compute distribution of R⋆ statistic for a mixed chain.
+        # Compute R⋆ statistic for a mixed chain.
         samples = randn(4 * N, 8)
         chain_indices = repeat(1:4, N)
         dist = rstar(classifier, samples, chain_indices)
 
-        # Mean of the resulting distribution should be closte to 1, i.e., the classifier
-        # does not perform better than random guessing.
+        # Mean of the statistic should be closte to 1, i.e., the classifier does not perform
+        # better than random guessing.
         if classifier isa MLJModels.Deterministic
-            @test dist isa Dirac
-            @test 0 <= minimum(dist) <= maximum(dist) <= 4
+            @test dist isa Float64
         else
             @test dist isa LocationScale
             @test dist.ρ isa PoissonBinomial
@@ -47,7 +45,7 @@ using Test
         end
         @test mean(dist) ≈ 1 rtol = 0.15
 
-        # Compute distribution of R⋆ statistic for a non-mixed chain.
+        # Compute the R⋆ statistic for a non-mixed chain.
         samples = [
             sin.(1:N) cos.(1:N)
             100 .* cos.(1:N) 100 .* sin.(1:N)
@@ -55,11 +53,10 @@ using Test
         chain_indices = repeat(1:2; inner=N)
         dist = rstar(classifier, samples, chain_indices)
 
-        # Mean of the resulting distribution should be close to 2, i.e., the classifier
-        # should be able to learn an almost perfect decision boundary between chains.
+        # Mean of the statistic should be close to 2, i.e., the classifier should be able to
+        # learn an almost perfect decision boundary between chains.
         if classifier isa MLJModels.Deterministic
-            @test dist isa Dirac
-            @test 0 <= minimum(dist) == maximum(dist) <= 2
+            @test dist isa Float64
         else
             @test dist isa LocationScale
             @test dist.ρ isa PoissonBinomial

--- a/test/rstar/runtests.jl
+++ b/test/rstar/runtests.jl
@@ -1,14 +1,17 @@
 using InferenceDiagnostics
 
 using Distributions
+using MLJBase
 using MLJModels
 
 using Test
 
+XGBoost = @load XGBoostClassifier verbosity = 0
+@pipeline XGBoost name=XGBoostDeterministic operation=predict_mode
+SVC = @load SVC verbosity = 0
+
 @testset "rstar.jl" begin
-    XGBoost = @load XGBoostClassifier verbosity = 0
-    SVC = @load SVC verbosity = 0
-    classifiers = (XGBoost(), SVC())
+    classifiers = (XGBoost(), XGBoostDeterministic(), SVC())
     N = 1_000
 
     @testset "examples (classifier = $classifier)" for classifier in classifiers

--- a/test/rstar/runtests.jl
+++ b/test/rstar/runtests.jl
@@ -6,8 +6,8 @@ using MLJModels
 using Test
 
 @testset "rstar.jl" begin
-    XGBoost = @load XGBoostClassifier verbosity=0
-    SVC = @load SVC verbosity=0
+    XGBoost = @load XGBoostClassifier verbosity = 0
+    SVC = @load SVC verbosity = 0
     classifiers = (XGBoost(), SVC())
     N = 1_000
 

--- a/test/rstar/runtests.jl
+++ b/test/rstar/runtests.jl
@@ -27,7 +27,7 @@ using Test
             @test minimum(dist) == 0
             @test maximum(dist) == 3
         end
-        @test mean(dist) ≈ 1 rtol = 0.15
+        @test mean(dist) ≈ 1 rtol = 0.2
 
         # Compute distribution of R⋆ statistic for a mixed chain.
         samples = randn(4 * N, 8)

--- a/test/rstar/runtests.jl
+++ b/test/rstar/runtests.jl
@@ -1,47 +1,79 @@
 using InferenceDiagnostics
+
+using Distributions
 using MLJModels
 
-using Statistics
 using Test
 
 @testset "rstar.jl" begin
-    XGBoost = @load XGBoostClassifier
-    classifier = XGBoost()
+    XGBoost = @load XGBoostClassifier verbosity=0
+    SVC = @load SVC verbosity=0
+    classifiers = (XGBoost(), SVC())
     N = 1_000
 
-    @testset "examples" begin
-        # Compute R* statistic for a mixed chain.
+    @testset "examples (classifier = $classifier)" for classifier in classifiers
+        # Compute distribution of R⋆ statistic for a mixed chain.
         samples = randn(N, 2)
-        R = rstar(classifier, randn(N, 2), rand(1:3, N))
+        dist = rstar(classifier, randn(N, 2), rand(1:3, N))
 
-        # Resulting R value should be close to one, i.e. the classifier does not perform better than random guessing.
-        @test Statistics.mean(R) ≈ 1 rtol = 0.15
+        # Mean of the resulting distribution should be focused around 1, i.e., the
+        # classifier does not perform better than random guessing.
+        if classifier isa MLJModels.Deterministic
+            @test dist isa Dirac
+            @test 0 <= minimum(dist) <= maximum(dist) <= 3
+        else
+            @test dist isa LocationScale
+            @test dist.ρ isa PoissonBinomial
+            @test minimum(dist) == 0
+            @test maximum(dist) == 3
+        end
+        @test mean(dist) ≈ 1 rtol = 0.15
 
-        # Compute R* statistic for a mixed chain.
+        # Compute distribution of R⋆ statistic for a mixed chain.
         samples = randn(4 * N, 8)
         chain_indices = repeat(1:4, N)
-        R = rstar(classifier, samples, chain_indices)
+        dist = rstar(classifier, samples, chain_indices)
 
-        # Resulting R value should be close to one, i.e. the classifier does not perform better than random guessing.
-        @test Statistics.mean(R) ≈ 1 rtol = 0.15
+        # Mean of the resulting distribution should be closte to 1, i.e., the classifier
+        # does not perform better than random guessing.
+        if classifier isa MLJModels.Deterministic
+            @test dist isa Dirac
+            @test 0 <= minimum(dist) <= maximum(dist) <= 4
+        else
+            @test dist isa LocationScale
+            @test dist.ρ isa PoissonBinomial
+            @test minimum(dist) == 0
+            @test maximum(dist) == 4
+        end
+        @test mean(dist) ≈ 1 rtol = 0.15
 
-        # Compute R* statistic for a non-mixed chain.
+        # Compute distribution of R⋆ statistic for a non-mixed chain.
         samples = [
             sin.(1:N) cos.(1:N)
             100 .* cos.(1:N) 100 .* sin.(1:N)
         ]
         chain_indices = repeat(1:2; inner=N)
+        dist = rstar(classifier, samples, chain_indices)
 
-        # Restuling R value should be close to two, i.e. the classifier should be able to learn an almost perfect decision boundary between chains.
-        R = rstar(classifier, samples, chain_indices)
-        @test Statistics.mean(R) ≈ 2 rtol = 5e-2
+        # Mean of the resulting distribution should be close to 2, i.e., the classifier
+        # should be able to learn an almost perfect decision boundary between chains.
+        if classifier isa MLJModels.Deterministic
+            @test dist isa Dirac
+            @test 0 <= minimum(dist) == maximum(dist) <= 2
+        else
+            @test dist isa LocationScale
+            @test dist.ρ isa PoissonBinomial
+            @test minimum(dist) == 0
+            @test maximum(dist) == 2
+        end
+        @test mean(dist) ≈ 2 rtol = 0.15
     end
 
-    @testset "exceptions" begin
+    @testset "exceptions (classifier = $classifier)" for classifier in classifiers
         @test_throws DimensionMismatch rstar(classifier, randn(N - 1, 2), rand(1:3, N))
-        for iterations in (-13, -1, 0)
+        for subset in (-0.3, 0, 1 / (3 * N), 1 - 1 / (3 * N), 1, 1.9)
             @test_throws ArgumentError rstar(
-                classifier, randn(N, 2), rand(1:3, N); iterations=iterations
+                classifier, randn(N, 2), rand(1:3, N); subset=subset
             )
         end
     end

--- a/test/rstar/runtests.jl
+++ b/test/rstar/runtests.jl
@@ -7,7 +7,7 @@ using MLJModels
 using Test
 
 XGBoost = @load XGBoostClassifier verbosity = 0
-@pipeline XGBoost name=XGBoostDeterministic operation=predict_mode
+@pipeline XGBoost name = XGBoostDeterministic operation = predict_mode
 SVC = @load SVC verbosity = 0
 
 @testset "rstar.jl" begin


### PR DESCRIPTION
This PR implements the suggestion in https://github.com/TuringLang/MCMCChains.jl/pull/263: the analytical distribution can be calculated explicitly and no sampling has to be performed.

This PR uses the more general location scale distribution in Distributions 0.25 instead of reimplementing a scaled Poisson-binomial distribution. Additionally, the pdf of the Poisson-binomial distribution is computed lazily in Distributions 0.25 which implies that the pdf values are never computed if one only evaluates the mean or variance of the distribution.